### PR TITLE
Delete .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,0 @@
-comment: off


### PR DESCRIPTION
this files doesn't actually disable bot comments, "comment: false" does

that aside, this isn't necessary anymore since I created a team-wide YAML to turn this functionality off