### PR TITLE
Simplify unlock

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -6,7 +6,7 @@
 
 const UUID = require("uuid"),
       ItemKeyStore = require("./itemkeystore"),
-      errors = require("./util/errors"),
+      DataStoreError = require("./util/errors"),
       instance = require("./util/instance"),
       localdatabase = require("./localdatabase"),
       jose = require("node-jose");
@@ -14,14 +14,14 @@ const UUID = require("uuid"),
 // BASE64URL(SHA-256("project lockbox"))
 const PASSWORD_PREFIX = "-GV3ItzyNxfBGp3ZjtqVGswWWlT7tIMZjeXanHqhxm0";
 
-const DEFAULT_PROMPTS = {
-  unlock: async (request) => {
-    if (1 < request.attempts) {
-      throw new errors.DataStoreError("too many attempts", errors.Reasons.GENERIC_ERROR);
-    }
-    return "";
+function checkState(ds) {
+  if (!ds.initialized) {
+    throw new DataStoreError("data is not initialized", DataStoreError.NOT_INITIALIZED);
   }
-};
+  if (ds.locked) {
+    throw new DataStoreError("datastore is locked", DataStoreError.LOCKED);
+  }
+}
 
 async function passwordToKey(pwd) {
   pwd = PASSWORD_PREFIX + pwd;
@@ -58,7 +58,6 @@ class DataStore {
     self.items = new Map();
 
     self.bucket = cfg.bucket;
-    self.prompts = Object.assign({}, DEFAULT_PROMPTS, cfg.prompts);
 
     // TESTING ONLY: accept an (encrypted) item keys map
     self.keystore = new ItemKeyStore({
@@ -98,30 +97,6 @@ class DataStore {
   }
 
   /**
-   * The prompt handling functions configured in this DataStore.
-   *
-   * The `{unlock}` handler function is expected to match the
-   * following:
-   *
-   * ```
-   * async function(request) {
-   *    // {request} is an Object containing the following members:
-   *    request.error;    // an Error describing a previous failure, if any
-   *    request.attempts; // the Number of attempts so far (including this one)
-   *    // returns a Promise containing the unlock secret (as a string)
-   * }
-   * ```
-   *
-   * @type {Object}
-   * @property {Function} unlock The prompt function called to handle {unlock}.
-   */
-  get prompts() { return Object.assign({}, instance.get(this).prompts); }
-  set prompts(p) {
-    let self = instance.get(this);
-    self.prompts = Object.assign({}, DEFAULT_PROMPTS, p || {});
-  }
-
-  /**
    * Indicates whether this DataStore is initialized.
    *
    * @type {Boolean}
@@ -153,7 +128,7 @@ class DataStore {
     // TODO: deal with (soft / hard) reset
     if (self.keystore.encrypted) {
       // TODO: specific error reason?
-      throw new errors.DataStoreError("already initialized", errors.Reasons.GENERIC_ERROR);
+      throw new DataStoreError("already initialized", DataStoreError.INITIALIZED);
     }
 
     opts = opts || {};
@@ -194,39 +169,25 @@ class DataStore {
   /**
    * Attempts to unlock this datastore.
    *
+   * @param {String} pwd The password to unlock the datastore.
    * @returns {DataStore} This DataStore once unlocked
    */
-  async unlock() {
+  async unlock(pwd) {
     let self = instance.get(this);
-    let { keystore, prompts } = self;
-    let masterKey, error, attempts = 0;
+    let { keystore } = self;
+    let masterKey;
 
-    // TODO: set a max attempts limit?
-    while (!keystore.masterKey) {
-      // prompt for the password
-      try {
-        attempts++;
+    if (!this.locked) {
+      // fast win
+      return this;
+    }
 
-        // prompt for the password
-        let req = {
-          error,
-          attempts
-        };
-        let pwd;
-        pwd = await prompts.unlock(req);
-        // try to decrypt item keys
-        // TODO: replace with something based on WebCrypto API
-        masterKey = await passwordToKey(pwd);
-        await keystore.load(masterKey);
-      } catch (err) {
-        masterKey = null;
-        if (errors.Reasons.ABORTED !== err.reason) {
-          throw err;
-        }
-        // try it again
-        // TODO: reformat errors to something more understandable?
-        error = err;
-      }
+    try {
+      masterKey = await passwordToKey(pwd);
+      await keystore.load(masterKey);
+    } catch (err) {
+      // TODO: differentiate errors?
+      throw err;
     }
 
     return this;
@@ -238,9 +199,9 @@ class DataStore {
    * @returns {Map<String, Object>} The map of stored item, by id
    */
   async list() {
-    await this.unlock();
-    let self = instance.get(this);
+    checkState(this);
 
+    let self = instance.get(this);
     let all;
     all = await self.ldb.items.toArray();
     all = all.map(async i => {
@@ -263,7 +224,8 @@ class DataStore {
    *          no item for `{id}`
    */
   async get(id) {
-    await this.unlock();
+    checkState(this);
+
     let self = instance.get(this);
     let one = await self.ldb.items.get(id);
     if (one) {
@@ -282,6 +244,8 @@ class DataStore {
    * @throws {TypeError} if `item` is invalid
    */
   async add(item) {
+    checkState(this);
+
     let self = instance.get(this);
     if (!item) {
       // TODO: custom errors
@@ -298,7 +262,6 @@ class DataStore {
     item.created = item.created || now;
     item.modified = item.modified || now;
 
-    await this.unlock();
     let active = !item.disabled ? "active" : "",
         encrypted = await self.keystore.encrypt(item);
 
@@ -327,14 +290,14 @@ class DataStore {
    * @throws {TypeError} if `item` is invalid
    */
   async update(item) {
-    let self = instance.get(this);
+    checkState(this);
 
+    let self = instance.get(this);
     if (!item || !item.id) {
       // TODO: custom errors
       throw new TypeError("invalid item");
     }
 
-    await this.unlock();
     let id = item.id;
     let orig = await self.ldb.items.get(id),
         encrypted;
@@ -375,9 +338,9 @@ class DataStore {
    * @returns {Object} The removed item, or `null` if no item was removed
    */
   async remove(id) {
-    let self = instance.get(this);
-    await this.unlock();
+    checkState(this);
 
+    let self = instance.get(this);
     let item = await self.ldb.items.get(id);
     if (item) {
       item = await self.keystore.decrypt(id, item.encrypted);

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -24,7 +24,7 @@ function checkState(ds) {
 }
 
 async function passwordToKey(pwd) {
-  pwd = PASSWORD_PREFIX + pwd;
+  pwd = PASSWORD_PREFIX + (pwd || "");
 
   let key = {
     kty: "oct",

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-const DataStore = require("./datastore");
+const DataStore = require("./datastore"),
+      DataStoreError = require("./util/errors");
 
 /**
  * @deprecated Replaced with the async function {@link open}, which
@@ -36,6 +37,7 @@ async function open(cfg) {
 }
 
 Object.assign(exports, {
+  DataStoreError,
   create,
   open
 });

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -4,13 +4,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-const Messages = {},
+const Messages = new Map(),
       Reasons = {};
 
-["ABORTED", "UNLOCK_ERROR", "SYNC_ERROR", "GENERIC_ERROR"].forEach(m => {
+[
+  "NOT_INITIALIZED",
+  "INITIALIZED",
+  "LOCKED",
+  "UNLOCK_ERROR",
+  "SYNC_ERROR",
+  "GENERIC_ERROR"
+].forEach(m => {
   let s = Symbol(m);
   Reasons[m] = s;
-  Messages[s] = m;
+  Messages.set(s, m);
 });
 
 class DataStoreError extends Error {
@@ -23,7 +30,7 @@ class DataStoreError extends Error {
       reason = Reasons.GENERIC_ERROR;
     }
     if (!message) {
-      message = Messages[reason];
+      message = Messages.get(reason);
     }
 
     super(message);
@@ -37,7 +44,9 @@ class DataStoreError extends Error {
   }
 }
 
-Object.assign(exports, {
-  Reasons,
-  DataStoreError
-});
+for (let e of Messages.entries()) {
+  let [s, m] = e;
+  DataStoreError[m] = s;
+}
+
+module.exports = DataStoreError;

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -4,49 +4,69 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-const Messages = new Map(),
-      Reasons = {};
-
-[
-  "NOT_INITIALIZED",
-  "INITIALIZED",
-  "LOCKED",
-  "UNLOCK_ERROR",
-  "SYNC_ERROR",
-  "GENERIC_ERROR"
-].forEach(m => {
-  let s = Symbol(m);
-  Reasons[m] = s;
-  Messages.set(s, m);
-});
-
+/**
+ * Errors specific to DataStore operations.
+ *
+ */
 class DataStoreError extends Error {
+  /**
+   * Creates a new DataStoreError with the given message and reason.
+   *
+   * @param {String} message - The error message
+   * @param {Symbol} [reason=DataStoreError.GENERIC_ERROR] - The reason for the error
+   */
   constructor(message, reason) {
     if ("symbol" === typeof message) {
       reason = message;
       message = "";
     }
     if (!reason) {
-      reason = Reasons.GENERIC_ERROR;
+      reason = DataStoreError.GENERIC_ERROR;
     }
     if (!message) {
-      message = Messages.get(reason);
+      message = /^Symbol\((.*)\)$/.exec(reason.toString())[1];
     }
 
     super(message);
     this.name = this.constructor.name;
-    this.reason = reason;
     if ("function" === Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     } else {
       this.stack = (new Error(message)).stack;
     }
+
+    /**
+     * The reason for this DataStoreError.
+     *
+     * @member {Symbol}
+     */
+    this.reason = reason;
   }
 }
 
-for (let e of Messages.entries()) {
-  let [s, m] = e;
-  DataStoreError[m] = s;
-}
+/**
+ * The datastore is not yet initialized.
+ *
+ * @type Symbol
+ */
+DataStoreError.NOT_INITIALIZED = Symbol("NOT_INITIALIZED");
+/**
+ * An attempt was made to initialize a datastore that is already initialized.
+ *
+ * @type Symbol
+ */
+DataStoreError.INITIALIZED = Symbol("INITIALIZED");
+/**
+ * An attempt was made to use a datastore that is still locked`.
+ *
+ * @type Symbol
+ */
+DataStoreError.LOCKED = Symbol("LOCKED");
+/**
+ * An otherwise unspecified error occured with the datastore.
+ *
+ * @type Symbol
+ */
+DataStoreError.GENERIC_ERROR = Symbol("GENERIC_ERROR");
 
 module.exports = DataStoreError;

--- a/test/datastore-test.js
+++ b/test/datastore-test.js
@@ -267,7 +267,7 @@ describe("datastore", () => {
       let main = new DataStore();
       main = await main.prepare();
       await main.initialize();
-      await main.unlock;
+      await main.unlock();
 
       let result = await main.add(something);
       assert.deepNestedInclude(result, something);

--- a/test/datastore-test.js
+++ b/test/datastore-test.js
@@ -6,6 +6,8 @@
 
 const assert = require("chai").assert;
 
+const UUID = require("uuid");
+
 const DataStore = require("../lib/datastore"),
       localdatabase = require("../lib/localdatabase"),
       DataStoreError = require("../lib/util/errors");
@@ -169,6 +171,58 @@ describe("datastore", () => {
 
       result = await main.get(result.id);
       assert(!result);
+    });
+
+    describe("locked failures", () => {
+      const item = {
+        id: UUID(),
+        title: "foobar",
+        entry: {
+          kind: "login",
+          username: "blah",
+          password: "dublah"
+        }
+      };
+
+      beforeEach(async () => {
+        await main.lock();
+      });
+
+      it("fails list if locked", async () => {
+        try {
+          await main.list();
+        } catch (err) {
+          assert.strictEqual(err.reason, DataStoreError.LOCKED);
+        }
+      });
+      it("fails get if locked", async () => {
+        try {
+          await main.get(item.id);
+        } catch (err) {
+          assert.strictEqual(err.reason, DataStoreError.LOCKED);
+        }
+      });
+      it("fails add if locked", async () => {
+        try {
+          await main.add(item);
+        } catch (err) {
+          assert.strictEqual(err.reason, DataStoreError.LOCKED);
+        }
+      });
+      it("fails update if locked", async () => {
+        try {
+          await main.update(item);
+        } catch (err) {
+          assert.strictEqual(err.reason, DataStoreError.LOCKED);
+        }
+      });
+      it("fails remove if locked", async () => {
+        try {
+          await main.remove(item);
+        } catch (err) {
+          assert.strictEqual(err.reason, DataStoreError.LOCKED);
+        }
+      });
     });
   });
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -7,9 +7,14 @@
 const assert = require("chai").assert;
 
 const index = require("../lib"),
-      DataStore = require("../lib/datastore");
+      DataStore = require("../lib/datastore"),
+      DataStoreError = require("../lib/util/errors");
 
 describe("index", () => {
+  it("has expected symbols", () => {
+    assert.strictEqual(index.DataStoreError, DataStoreError);
+    assert.typeOf(index.open, "function");
+  });
   it("opens a DataStore instance", async () => {
     let data = index.open();
     // make sure it quacks enough like a duck

--- a/test/util/errors-test.js
+++ b/test/util/errors-test.js
@@ -11,39 +11,39 @@ const assert = Object.assign({}, require("chai").assert, {
   }
 });
 
-const errors = require("../../lib/util/errors");
+const DataStoreError = require("../../lib/util/errors");
 
 describe("util/errors", () => {
   describe("Reasons", () => {
     it("checks for expected reasons", () => {
-      let { Reasons } = errors;
-      assert.reasonMatches(Reasons.ABORTED, "ABORTED");
-      assert.reasonMatches(Reasons.SYNC_ERROR, "SYNC_ERROR");
-      assert.reasonMatches(Reasons.UNLOCK_ERROR, "UNLOCK_ERROR");
-      assert.reasonMatches(Reasons.GENERIC_ERROR, "GENERIC_ERROR");
+      assert.reasonMatches(DataStoreError.INITIALIZED, "INITIALIZED");
+      assert.reasonMatches(DataStoreError.NOT_INITIALIZED, "NOT_INITIALIZED");
+      assert.reasonMatches(DataStoreError.LOCKED, "LOCKED");
+      assert.reasonMatches(DataStoreError.SYNC_ERROR, "SYNC_ERROR");
+      assert.reasonMatches(DataStoreError.UNLOCK_ERROR, "UNLOCK_ERROR");
+      assert.reasonMatches(DataStoreError.GENERIC_ERROR, "GENERIC_ERROR");
     });
   });
   describe("DataStoreError", () => {
-    let { Reasons, DataStoreError } = errors;
     it("creates with all arguments", () => {
       let err;
-      err = new DataStoreError("some generic error", Reasons.GENERIC_ERROR);
+      err = new DataStoreError("some generic error", DataStoreError.GENERIC_ERROR);
       assert.strictEqual(err.message, "some generic error");
-      assert.strictEqual(err.reason, Reasons.GENERIC_ERROR);
+      assert.strictEqual(err.reason, DataStoreError.GENERIC_ERROR);
       assert.notEmpty(err.stack);
     });
     it("creates with missing reason", () => {
       let err;
       err = new DataStoreError("some other error");
       assert.strictEqual(err.message, "some other error");
-      assert.strictEqual(err.reason, Reasons.GENERIC_ERROR);
+      assert.strictEqual(err.reason, DataStoreError.GENERIC_ERROR);
       assert.notEmpty(err.stack);
     });
     it("creates with missing message", () => {
       let err;
-      err = new DataStoreError(Reasons.GENERIC_ERROR);
+      err = new DataStoreError(DataStoreError.GENERIC_ERROR);
       assert.strictEqual(err.message, "GENERIC_ERROR");
-      assert.strictEqual(err.reason, Reasons.GENERIC_ERROR);
+      assert.strictEqual(err.reason, DataStoreError.GENERIC_ERROR);
       assert.notEmpty(err.stack);
     });
   });

--- a/test/util/errors-test.js
+++ b/test/util/errors-test.js
@@ -16,11 +16,9 @@ const DataStoreError = require("../../lib/util/errors");
 describe("util/errors", () => {
   describe("Reasons", () => {
     it("checks for expected reasons", () => {
-      assert.reasonMatches(DataStoreError.INITIALIZED, "INITIALIZED");
       assert.reasonMatches(DataStoreError.NOT_INITIALIZED, "NOT_INITIALIZED");
+      assert.reasonMatches(DataStoreError.INITIALIZED, "INITIALIZED");
       assert.reasonMatches(DataStoreError.LOCKED, "LOCKED");
-      assert.reasonMatches(DataStoreError.SYNC_ERROR, "SYNC_ERROR");
-      assert.reasonMatches(DataStoreError.UNLOCK_ERROR, "UNLOCK_ERROR");
       assert.reasonMatches(DataStoreError.GENERIC_ERROR, "GENERIC_ERROR");
     });
   });


### PR DESCRIPTION
This matches discussions on how `unlock()` ought to behave:

* takes the password to unlock with
* tries once, and returning this DataStore if successful, and throws an error otherwise
* all other methods first check the lock state, throwing a LOCKED error if locked