### PR TITLE
Quick draft of codeowners for reviews

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,11 @@
+# lockbox-datastore code owners
+# https://help.github.com/articles/about-codeowners/
+
+# tests should also be reviewed by @m8ttyB
+/test/    @linuxwolf @m8ttyB
+
+# docs are shepherded by @devinreams
+/docs/    @linuxwolf @devinreams
+
+# otherwise, everything is to be reviewed by @linuxwolf
+*         @linuxwolf


### PR DESCRIPTION
I'm in a documentation mood.

This will automatically add the matching code owner(s) to PR reviews (later rules take precedence): https://help.github.com/articles/about-codeowners/