### PR TITLE
Build: fix up script runs to account for docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 coverage
+site
+node_modules

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "doc": "documentation build lib/** -f md -o docs/api.md",
     "postdoc": "mkdocs build",
+    ":clean:doc": "git clean -fdX ./site ./docs",
     "lint": "eslint .",
     "pretest": "npm run lint && npm run :clean:coverage",
     ":test:karma": "karma start",
@@ -20,7 +21,7 @@
     "watch": "watch --interval=10 'npm run test && npm run doc' ./lib ./test",
     ":clean:coverage": "git clean -fdX ./coverage",
     "codecov": "codecov",
-    "clean": "npm run :clean:coverage"
+    "clean": "npm run :clean:coverage && npm run :clean:doc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "karma-mocha-reporter": "^2.2.3",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.4",
-    "mkdocs": "0.0.1",
     "mocha": "^3.5.0",
     "nyc": "^11.0.3",
     "password": "^0.1.1",


### PR DESCRIPTION
Without this, running `npm run lint` will fail because of problems in `./site`.

Also explicitly cleans up all generated documentation