### PR TITLE
Add design doc to mkdocs pages inventory

### DIFF
--- a/docs/data-storage.md
+++ b/docs/data-storage.md
@@ -1,8 +1,3 @@
----
-title: Data Storage Design
-layout: default
----
-
 # Lockbox Data Storage
 
 ## Overview

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ repo_url: https://github.com/mozilla-lockbox/lockbox-datastore
 
 pages:
 - 'Introduction': 'index.md'
+- 'Data Storage Design': 'data-storage.md'
 - 'Installing': 'install.md'
 - 'Contributing': 'contributing.md'
 - 'Code of Conduct': 'code_of_conduct.md'


### PR DESCRIPTION
This way it appears in the table of contents / navigation on the website.