### PR TITLE
feature: (local) database version checking

### DIFF
--- a/lib/localdatabase.js
+++ b/lib/localdatabase.js
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+const DataStoreError = require("./util/errors");
+
 const Dexie = require("dexie"),
       indexedDB = require("fake-indexeddb"),
       IDBKeyRange = require("fake-indexeddb/lib/FDBKeyRange");
@@ -29,6 +31,7 @@ if (Object.keys(indexedDB).length && Object.keys(IDBKeyRange).length) {
  * @memberof localdatabase
  */
 const DEFAULT_BUCKET = "lockbox";
+const DATABASE_VERSION = 0.1;
 
 let DATABASES;
 
@@ -54,7 +57,11 @@ async function open(bucket) {
     DATABASES.add(db);
   }
 
-  return db.open();
+  await db.open();
+  if (db.verno !== DATABASE_VERSION) {
+    throw new DataStoreError("invalid indexeddb version", DataStoreError.LOCALDB_VERSION);
+  }
+  return db;
 }
 
 /**
@@ -90,5 +97,6 @@ Object.assign(exports, {
   open,
   teardown,
   startup,
-  DEFAULT_BUCKET
+  DEFAULT_BUCKET,
+  DATABASE_VERSION
 });

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -57,6 +57,13 @@ DataStoreError.NOT_INITIALIZED = Symbol("NOT_INITIALIZED");
  */
 DataStoreError.INITIALIZED = Symbol("INITIALIZED");
 /**
+ * When opening the local database, the actual databse version does not
+ * metch the expected version.
+ *
+ * @type Symbol
+ */
+DataStoreError.LOCALDB_VERSION = Symbol("LOCALDB_VERSION");
+/**
  * An attempt was made to use a datastore that is still locked`.
  *
  * @type Symbol

--- a/test/localdatabase-test.js
+++ b/test/localdatabase-test.js
@@ -1,0 +1,47 @@
+/*!
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const assert = require("chai").assert;
+
+const DataStoreError = require("../lib/util/errors"),
+      localdatabase = require("../lib/localdatabase");
+
+describe("localdatabase", () => {
+  let ldb;
+
+  beforeEach(async () => {
+    ldb = null;
+    await localdatabase.startup();
+  });
+  afterEach(async () => {
+    if (ldb) {
+      await ldb.close();
+    }
+    await localdatabase.teardown();
+  });
+
+  it("opens a default instance", async () => {
+    ldb = await localdatabase.open();
+    assert.strictEqual(ldb.name, localdatabase.DEFAULT_BUCKET);
+  });
+  it("opens the named instance", async () => {
+    const name = "lockbox-devel";
+    ldb = await localdatabase.open(name);
+    assert.strictEqual(ldb.name, name);
+  });
+  it("fails to open an unexpected instance", async () => {
+    const name = "lockbox-bad";
+    let prep = await localdatabase.open(name);
+    await prep.close();
+    await prep.version(0.2);
+    try {
+      ldb = await localdatabase.open(name);
+    } catch (err) {
+      console.log(`failure ${err.message}`); //eslint-disable-line
+      assert.strictEqual(err.reason, DataStoreError.LOCALDB_VERSION);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #40

It will throw an error if the reported IndexedDB version does not match the (hard coded) expected version.  This should only be the case if the reported version is greater than expected version; if the reported version is less than the expected version, Dexie calls the provided `upgrade` callback (if needed) and increments the reported version to match.