### PR TITLE
Item Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ node_js:
 addons:
   firefox: latest-beta
 
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
-
 # DEFAULTS: Travis runs `npm install` and `npm test`
 
 after_success:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,10 +4,22 @@ let setup = require("./karma.conf-base.js");
 
 module.exports = function(config) {
   setup(config, {
+    // custom mocha config
+    client: {
+      mocha: {
+        timeout: 10000
+      }
+    },
     // single run ONLY
     singleRun: true,
+    customLaunchers: {
+      FirefoxHeadless: {
+        base: "Firefox",
+        flags: "-headless"
+      }
+    },
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ["Firefox"]
+    browsers: ["FirefoxHeadless"]
   });
 };

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -311,7 +311,7 @@ class DataStore {
         active = !item.disabled ? "active" : "",
         encrypted = await self.keystore.encrypt(item);
 
-    item = {
+    let record = {
       id,
       active,
       encrypted
@@ -319,11 +319,9 @@ class DataStore {
     let ldb = self.ldb;
     await self.keystore.save();
     await ldb.transaction("rw", ldb.items, ldb.keystores, () => {
-      ldb.items.add(item);
+      ldb.items.add(record);
       ldb.keystores.put(self.keystore.toJSON());
     });
-    // TODO: find a more efficient way to get a cleaned item
-    item = await self.keystore.decrypt(id, encrypted);
     self.recordMetric("added", item.id);
 
     return item;
@@ -367,12 +365,12 @@ class DataStore {
     let active = !item.disabled ? "active" : "";
     encrypted = await self.keystore.encrypt(item);
 
-    orig = {
+    let record = {
       id,
       active,
       encrypted
     };
-    await self.ldb.items.put(orig);
+    await self.ldb.items.put(record);
     self.recordMetric("updated", item.id, changes.fields);
 
     return item;

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-const UUID = require("uuid"),
+const Items = require("./items"),
       ItemKeyStore = require("./itemkeystore"),
       DataStoreError = require("./util/errors"),
       instance = require("./util/instance"),
@@ -304,17 +304,11 @@ class DataStore {
       throw new TypeError("expected item");
     }
 
-    // TODO: check for existing item?
-    // TODO: deep copy
-    let id = UUID(),
-        now = new Date();
+    // validate, and fill defaults into, {item}
+    item = Items.prepare(item);
 
-    item = Object.assign({}, item);
-    item.id = id;
-    item.created = item.created || now;
-    item.modified = item.modified || now;
-
-    let active = !item.disabled ? "active" : "",
+    let id = item.id,
+        active = !item.disabled ? "active" : "",
         encrypted = await self.keystore.encrypt(item);
 
     item = {
@@ -361,20 +355,12 @@ class DataStore {
     }
 
     orig = await self.keystore.decrypt(id, encrypted);
-    // TODO: better deep copy?
-    // TODO: separate out immutable fields (history, created, etc)
-    item = JSON.parse(JSON.stringify(item));
+    item = Items.prepare(item, orig);
 
     let changes = determineItemChanges(orig, item);
-    // TOOD: apply patch
-    Object.assign(orig, item);
-    orig.modified = new Date();
 
-    // TODO: find a more efficient way to get a cleaned item
-    item = JSON.parse(JSON.stringify(orig));
-
-    let active = !orig.disabled ? "active" : "";
-    encrypted = await self.keystore.encrypt(orig);
+    let active = !item.disabled ? "active" : "";
+    encrypted = await self.keystore.encrypt(item);
 
     orig = {
       id,

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -331,10 +331,15 @@ class DataStore {
   /**
    * Updates an existing item in this DataStore.
    *
+   * `{item}` is expected to be a complete object; any (mutable) fields missing
+   * are removed from the stored value.  API users should call {@link #get},
+   * then make the desired changes to the returned value.
+   *
    * @param {Object} item - The item to update
    * @returns {Object} The updated item
    * @throws {Error} if this item does not exist
-   * @throws {TypeError} if `item` is invalid
+   * @throws {TypeError} if `item` is not an object with a `id` member
+   * @throws {DataStoreError} if the `item` violates the schema
    */
   async update(item) {
     checkState(this);

--- a/lib/items.js
+++ b/lib/items.js
@@ -1,0 +1,62 @@
+/*!
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const jsonmergepatch = require("json-merge-patch"),
+      joi = require("joi"),
+      UUID = require("uuid");
+      
+const DataStoreError = require("./util/errors");
+
+const BASE_ENTRY_SCHEMA = joi.object().keys({
+  kind: joi.string().required(),
+  notes: joi.string().max(10000),
+});
+const ENTRY_SCHEMAS = [
+  BASE_ENTRY_SCHEMA.keys({
+    kind: "login",
+    username: joi.string().max(500),
+    password: joi.string().max(500),
+  }),
+];
+const SCHEMA = joi.object().keys({
+  title: joi.string().max(500),
+  origins: joi.array().items(joi.string().max(500)).max(5),
+  tags: joi.array().items(joi.string().max(500)).max(10),
+  entry: joi.alternatives(ENTRY_SCHEMAS).required(),
+});
+
+const HISTORY_MAX = 100;
+
+function prepare(item, source) {
+  // strip out anything not in the whitelist
+  let { error, value: destination } = SCHEMA.validate(item, { stripUnknown: true });
+  if (error) {
+    throw new DataStoreError("item changes invalid", DataStoreError.INVALID_ITEM);
+  }
+  
+  // apply read-only values
+  source = source || {};
+  destination.id = source.id || UUID();
+  destination.created = source.created || new Date().toISOString();
+  destination.modified = source.modified || new Date().toISOString();
+  destination.disabled = source.disabled || false;
+  
+  // generate history patch (to go backward)
+  let dstEntry = destination.entry,
+      srcEntry = source.entry || {};
+  let patch = jsonmergepatch.generate(dstEntry, srcEntry);
+  let history = (source.history || []).slice(0, HISTORY_MAX - 1);
+  history.shift({
+    created: new Date().toISOString(),
+    patch
+  });
+  destination.history = history;
+  return destination;
+}
+
+Object.assign(exports, {
+  prepare
+});

--- a/lib/items.js
+++ b/lib/items.js
@@ -10,31 +10,44 @@ const jsonmergepatch = require("json-merge-patch"),
       
 const DataStoreError = require("./util/errors");
 
+const STRING_500 = joi.string().max(500).allow("").allow(null).default("");
+const STRING_10K = joi.string().max(10000).allow("").allow(null).default("");
 const BASE_ENTRY_SCHEMA = joi.object().keys({
   kind: joi.string().required(),
-  notes: joi.string().max(10000),
+  notes: STRING_10K
 });
 const ENTRY_SCHEMAS = [
   BASE_ENTRY_SCHEMA.keys({
     kind: "login",
-    username: joi.string().max(500),
-    password: joi.string().max(500),
+    username: STRING_500,
+    password: STRING_500
   }),
 ];
 const SCHEMA = joi.object().keys({
-  title: joi.string().max(500),
-  origins: joi.array().items(joi.string().max(500)).max(5),
-  tags: joi.array().items(joi.string().max(500)).max(10),
+  title: STRING_500,
+  origins: joi.array().items(STRING_500).max(5).default([]),
+  tags: joi.array().items(STRING_500).max(10).default([]),
   entry: joi.alternatives(ENTRY_SCHEMAS).required(),
 });
+const VALIDATE_OPTIONS = {
+  abortEarly: false,
+  stripUnknown: true
+};
 
 const HISTORY_MAX = 100;
 
 function prepare(item, source) {
   // strip out anything not in the whitelist
-  let { error, value: destination } = SCHEMA.validate(item, { stripUnknown: true });
+  let { error, value: destination } = SCHEMA.validate(item, VALIDATE_OPTIONS);
   if (error) {
-    throw new DataStoreError("item changes invalid", DataStoreError.INVALID_ITEM);
+    let details = error.details;
+    let thrown = new DataStoreError("item changes invalid", DataStoreError.INVALID_ITEM);
+    thrown.details = {};
+    details.forEach((d) => {
+      let path = Array.isArray(d.path) ? d.path.join(".") : d.path;
+      thrown.details[path] = d.type;
+    });
+    throw thrown;
   }
   
   // apply read-only values

--- a/lib/items.js
+++ b/lib/items.js
@@ -40,20 +40,27 @@ function prepare(item, source) {
   // apply read-only values
   source = source || {};
   destination.id = source.id || UUID();
-  destination.created = source.created || new Date().toISOString();
-  destination.modified = source.modified || new Date().toISOString();
   destination.disabled = source.disabled || false;
+  destination.created = source.created || new Date().toISOString();
+  // always assume the item is modified
+  destination.modified = new Date().toISOString();
   
   // generate history patch (to go backward)
-  let dstEntry = destination.entry,
-      srcEntry = source.entry || {};
-  let patch = jsonmergepatch.generate(dstEntry, srcEntry);
-  let history = (source.history || []).slice(0, HISTORY_MAX - 1);
-  history.shift({
-    created: new Date().toISOString(),
-    patch
-  });
+  let history = [];
+  if (source && source.entry) {
+    history = (source.history || []).slice(0, HISTORY_MAX - 1);
+    let dstEntry = destination.entry,
+        srcEntry = source.entry;
+    let patch = jsonmergepatch.generate(dstEntry, srcEntry);
+    if (undefined !== patch) {
+      history.unshift({
+        created: new Date().toISOString(),
+        patch
+      });
+    }
+  }
   destination.history = history;
+
   return destination;
 }
 

--- a/lib/util/errors.js
+++ b/lib/util/errors.js
@@ -70,6 +70,12 @@ DataStoreError.LOCALDB_VERSION = Symbol("LOCALDB_VERSION");
  */
 DataStoreError.LOCKED = Symbol("LOCKED");
 /**
+ * The item to be added/updated is invalid.
+ *
+ * @type Symbol
+ */
+DataStoreError.INVALID_ITEM = Symbol("INVALID_ITEM");
+/**
  * An otherwise unspecified error occured with the datastore.
  *
  * @type Symbol

--- a/package-lock.json
+++ b/package-lock.json
@@ -2763,6 +2763,11 @@
         }
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -6264,6 +6269,21 @@
       "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
       "dev": true
     },
+    "isemail": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
+      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6478,6 +6498,28 @@
         "handlebars": "4.0.10"
       }
     },
+    "joi": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.1.tgz",
+      "integrity": "sha512-ChTMfmbIg5yrN9pUdeaLL8vzylMQhUteXiXa1MWINsMUs3jTQ8I87lUZwR5GdfCLJlpK04U7UgrxgmU8Zp7PhQ==",
+      "requires": {
+        "hoek": "5.0.0",
+        "isemail": "3.0.0",
+        "topo": "3.0.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.0.tgz",
+          "integrity": "sha512-/eDT+s5IgB/MR88VEIF8bYqqRiQ2yPownGng7NrmQzRv0kntBnDF68JBcpxVsnuOqDjmkemEoKlF+ln4z4NY0g=="
+        }
+      }
+    },
+    "joi-browser": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/joi-browser/-/joi-browser-10.6.1.tgz",
+      "integrity": "sha1-HPwaJEySQjJ4QsJDVNjq0cL+NXE="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -6518,6 +6560,14 @@
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
       "dev": true
+    },
+    "json-merge-patch": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-merge-patch/-/json-merge-patch-0.2.3.tgz",
+      "integrity": "sha1-+ixrWvh9p3uuKWalidUuI+2B/kA=",
+      "requires": {
+        "deep-equal": "1.0.1"
+      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -11319,6 +11369,21 @@
           "requires": {
             "kind-of": "3.2.2"
           }
+        }
+      }
+    },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.0.tgz",
+          "integrity": "sha512-/eDT+s5IgB/MR88VEIF8bYqqRiQ2yPownGng7NrmQzRv0kntBnDF68JBcpxVsnuOqDjmkemEoKlF+ln4z4NY0g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "browser": {
     "fake-indexeddb": false,
-    "fake-indexeddb/lib/FDBKeyRange": false
+    "fake-indexeddb/lib/FDBKeyRange": false,
+    "joi": "joi-browser"
   },
   "scripts": {
     "doc": "documentation build lib/** -f md -o docs/api.md",
@@ -72,6 +73,9 @@
   "dependencies": {
     "dexie": "^1.5.1",
     "fake-indexeddb": "^2.0.3",
+    "joi": "^13.0.1",
+    "joi-browser": "^10.6.1",
+    "json-merge-patch": "^0.2.3",
     "node-jose": "^0.10.0",
     "uuid": "^3.1.0"
   }

--- a/test/items-test.js
+++ b/test/items-test.js
@@ -1,0 +1,71 @@
+/*!
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const assert = require("./setup/assert"),
+      UUID = require("uuid");
+
+const Items = require("../lib/items");
+
+const ITEM_MEMBERS = [ "id", "title", "origins", "tags", "entry", "disabled", "created", "modified", "history" ];
+describe("items", () => {
+  it("prepares an item with all mutables and no source", () => {
+    let item = {
+      title: "some title",
+      origins: ["example.com"],
+      tags: ["personal"],
+      entry: {
+        kind: "login",
+        uesername: "someone",
+        password: "secret",
+        notes: "some notes for the entry"
+      }
+    };
+    
+    let result = Items.prepare(item);
+    assert(item !== result);
+    assert.hasAllKeys(result, ITEM_MEMBERS);
+  });
+  it("prepares an item with all mutables and a source", () => {
+    let source = {
+      id: UUID(),
+      title: "some title",
+      origins: ["example.com"],
+      tags: ["personal"],
+      entry: {
+        kind: "login",
+        username: "someone",
+        password: "secret"
+      },
+      created: new Date().toISOString(),
+      modified: new Date().toISOString(),
+      disabled: false
+    };
+    let item = {
+      title: "some title",
+      origins: ["example.net"],
+      tags: ["personal"],
+      entry: {
+        kind: "login",
+        username: "someone",
+        password: "another-secret",
+        notes: "my personal account details"
+      }
+    };
+    
+    let result = Items.prepare(item, source);
+    assert(result !== item);
+    assert(result !== source);
+    assert.itemMatches(result, Object.assign({history: [
+      {
+        created: new Date().toISOString(),
+        patch: {
+          password: "secret",
+          notes: null
+        }
+      }
+    ]}, source, item));
+  });
+});

--- a/test/items-test.js
+++ b/test/items-test.js
@@ -4,68 +4,434 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-const assert = require("./setup/assert"),
+const assert = require("./setup/assert");
+
+
+const jsonmergepatch = require("json-merge-patch"),
       UUID = require("uuid");
 
-const Items = require("../lib/items");
+const DataStoreError = require("../lib/util/errors"),
+      Items = require("../lib/items");
 
 const ITEM_MEMBERS = [ "id", "title", "origins", "tags", "entry", "disabled", "created", "modified", "history" ];
+const ENTRY_MEMBERS = ["kind", "username", "password", "notes"];
 describe("items", () => {
-  it("prepares an item with all mutables and no source", () => {
-    let item = {
-      title: "some title",
-      origins: ["example.com"],
-      tags: ["personal"],
-      entry: {
-        kind: "login",
-        uesername: "someone",
-        password: "secret",
-        notes: "some notes for the entry"
-      }
-    };
-    
-    let result = Items.prepare(item);
-    assert(item !== result);
-    assert.hasAllKeys(result, ITEM_MEMBERS);
-  });
-  it("prepares an item with all mutables and a source", () => {
-    let source = {
-      id: UUID(),
-      title: "some title",
-      origins: ["example.com"],
-      tags: ["personal"],
-      entry: {
-        kind: "login",
-        username: "someone",
-        password: "secret"
-      },
-      created: new Date().toISOString(),
-      modified: new Date().toISOString(),
-      disabled: false
-    };
-    let item = {
-      title: "some title",
-      origins: ["example.net"],
-      tags: ["personal"],
-      entry: {
-        kind: "login",
-        username: "someone",
-        password: "another-secret",
-        notes: "my personal account details"
-      }
-    };
-    
-    let result = Items.prepare(item, source);
-    assert(result !== item);
-    assert(result !== source);
-    assert.itemMatches(result, Object.assign({history: [
-      {
-        created: new Date().toISOString(),
-        patch: {
+  describe("happy", () => {
+    it("prepares an item with all mutables and no source", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
           password: "secret",
-          notes: null
+          notes: "some notes for the entry"
         }
+      };
+      
+      let result = Items.prepare(item);
+      assert(item !== result);
+      assert.hasAllKeys(result, ITEM_MEMBERS);
+      assert.hasAllKeys(result.entry, ENTRY_MEMBERS);
+      assert.itemMatches(result, Object.assign({}, item, {
+        disabled: false,
+        created: new Date().toISOString(),
+        modified: new Date().toISOString(),
+        history: []
+      }));
+    });
+    it("prepares an item with all mutables and a source", () => {
+      let history = [];
+      let source = {
+        id: UUID(),
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret"
+        },
+        disabled: false,
+        created: new Date().toISOString(),
+        modified: new Date().toISOString(),
+        history: []
+      };
+      let item = {
+        title: "some title",
+        origins: ["example.net"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "another-secret",
+          notes: "my personal account details"
+        }
+      };
+      history.unshift({
+        created: new Date().toISOString(),
+        patch: jsonmergepatch.generate(item.entry, source.entry)
+      });
+      
+      let result = Items.prepare(item, source);
+      assert(result !== item);
+      assert(result !== source);
+      assert.itemMatches(result, Object.assign({}, source, item, {
+        modified: new Date().toISOString(),
+        history
+      }));
+    });
+    it("prepares an item with some mutables and no source", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret"
+        }
+      };
+      
+      let result = Items.prepare(item);
+      assert(result !== item);
+      assert.hasAllKeys(result, ITEM_MEMBERS);
+      assert.itemMatches(result, Object.assign({}, item, {
+        disabled: false,
+        created: new Date().toISOString(),
+        modified: new Date().toISOString(),
+        history: []
+      }));
+    });
+    it("prepares an item with some mutables and a source", () => {
+      let history = [];
+      let source = {
+        id: UUID(),
+        title: "some title",
+        origins: ["example.net"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret"
+        }
+      };
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        entry: {
+          kind: "login",
+          username: "someone@example.com",
+          password: "secret"
+        }
+      };
+      history.unshift({
+        created: new Date().toISOString(),
+        patch: jsonmergepatch.generate(item.entry, source.entry)
+      });
+      
+      let result = Items.prepare(item, source);
+      assert(result !== item);
+      assert.hasAllKeys(result, ITEM_MEMBERS);
+      assert.itemMatches(result, Object.assign({}, source, item, {
+        tags: [],
+        disabled: false,
+        created: new Date().toISOString(),
+        modified: new Date().toISOString(),
+        history
+      }));
+    });
+    it("prepares an item without extras", () => {
+      let item = {
+        title: "some title",
+        extra: ["EXTRA!", "READ", "ALL", "ABOUT", "IT!"],
+        entry: {
+          kind: "login",
+          username: "someone"
+        }
+      };
+      
+      let result = Items.prepare(item);
+      assert(result !== item);
+      assert.hasAllKeys(result, ITEM_MEMBERS);
+      assert.hasAllKeys(result.entry, ENTRY_MEMBERS);
+    });
+  });
+  
+  describe("sad", () => {
+    function packString(max) {
+      const ALPHA = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789- ";
+      let out = [];
+      let len = Math.ceil(max + 1.5);
+      for (let idx = 0; idx < len; idx++) {
+        let c = Math.floor(Math.random() * ALPHA.length);
+        c = ALPHA.charAt(c);
+        out.push(c);
       }
-    ]}, source, item));
+      return out.join("");
+    }
+    function packOrigins(item) {
+      for (let idx = 0; idx < 17; idx++) {
+        item.origins.push(`domain-${idx}.example`);
+      }
+      return item;
+    }
+    function packTags(item) {
+      for (let idx = 0; idx < 17; idx++) {
+        item.tags.push(`personal-${idx}`);
+      }
+      return item;
+    }
+    
+    it("fails to prepare an item without an entry", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+      };
+
+      try {
+        Items.prepare(item);
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          entry: "any.required"
+        });
+      }
+    });
+    it("fails to prepare an item with an entry without a kind", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          username: "someone",
+          password: "secret"
+        }
+      };
+
+      try {
+        Items.prepare(item);
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          entry: "any.required"
+        });
+      }
+    });
+    it("fails to prepare an item with excessive title", () => {
+      let item = {
+        title: packString(500),
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret"
+        }
+      };
+
+      try {
+        Items.prepare(item);
+        assert(false, "expected failure");
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          title: "string.max"
+        });
+      }
+    });
+    it("fails to prepare an item with excessive origin item", () => {
+      let item = {
+        title: "some title",
+        origins: [packString(500)],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret"
+        }
+      };
+
+      try {
+        Items.prepare(item);
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          origins: "string.max"
+        });
+      }
+    });
+    it("fails to prepare an item with too many origins", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret"
+        }
+      };
+      item = packOrigins(item);
+
+      try {
+        Items.prepare(item);
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          origins: "array.max"
+        });
+      }
+    });
+    it("fails to prepare an item with excessive tag item", () => {
+      let item = {
+        title: "some title",
+        origin: ["example.com"],
+        tags: [packString(500)],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret"
+        }
+      };
+
+      try {
+        Items.prepare(item);
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          tags: "string.max"
+        });
+      }
+    });
+    it("fails to prepare an item with too many tags", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret",
+          notes: "some notes"
+        }
+      };
+      item = packTags(item);
+
+      try {
+        Items.prepare(item);
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          tags: "array.max"
+        });
+      }
+    });
+    it("fails to prepare an item with excessive entry.username", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: packString(500),
+          password: "secret",
+          notes: "some notes"
+        }
+      };
+
+      try {
+        Items.prepare(item);
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          "entry.username": "string.max"
+        });
+      }
+    });
+    it("fails to prepare an item with excessive entry.psssword", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: packString(500),
+          notes: "some notes"
+        }
+      };
+
+      try {
+        Items.prepare(item);
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          "entry.password": "string.max"
+        });
+      }
+    });
+    it("fails to prepare an item with excessive entry.notes", () => {
+      let item = {
+        title: "some title",
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: "someone",
+          password: "secret",
+          notes: packString(10000)
+        }
+      };
+
+      try {
+        Items.prepare(item);
+        assert(false, "expected failure");
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          "entry.notes": "string.max"
+        });
+      }
+    });
+    it("fails to prepare an item with multiple problems", () => {
+      let item = {
+        title: packString(500),
+        origins: ["example.com"],
+        tags: ["personal"],
+        entry: {
+          kind: "login",
+          username: packString(500),
+          password: "secret",
+          notes: packString(10000)
+        }
+      };
+      item = packOrigins(item);
+
+      try {
+        Items.prepare(item);
+        assert(false, "expected failure");
+      } catch (err) {
+        assert.strictEqual(err.message, "item changes invalid");
+        assert.strictEqual(err.reason, DataStoreError.INVALID_ITEM);
+        assert.deepEqual(err.details, {
+          "title": "string.max",
+          "origins": "array.max",
+          "entry.username": "string.max",
+          "entry.notes": "string.max"
+        });
+      }
+    });
   });
 });

--- a/test/setup/assert.js
+++ b/test/setup/assert.js
@@ -1,0 +1,53 @@
+/*!
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const assert = require("chai").assert;
+
+const ACCEPTED_DELTA_MS = 100;
+
+function dateInRange(actual, expected, message) {
+  actual = new Date(actual);
+  expected = new Date(expected);
+  let delta = Math.abs(actual.getTime() - expected.getTime());
+  message = `${message || "date out of range"}: ${actual} vs ${expected}`;
+  assert(delta < ACCEPTED_DELTA_MS, message);
+}
+
+const DATE_MEMBERS = ["created", "modified", "last_used"];
+function itemMatches(actual, expected, message, parent) {
+  let prefix = parent ? `${parent}: ` : "";
+  if (!expected) {
+    assert(actual == expected, prefix + `${message || "actual item exists"}`);
+    return;
+  }
+
+  assert(actual, prefix + `${message || "actual item does not exist"}`);
+  Object.keys(expected).forEach((m) => {
+    let mPrefix = `${parent ? parent + "." : ""}.${m}: `;
+    let actVal = actual[m],
+        expVal = expected[m];
+    
+    if (DATE_MEMBERS.indexOf(m) !== -1) {
+      dateInRange(actVal, expVal, prefix + `${m} out of range`);
+    } else if (Array.isArray(expVal)) {
+      assert(Array.isArray(actVal));
+      assert.strictEqual(actVal.length, expVal.length, prefix + `${message || "array length mismatch"}`);
+      for (let idx = 0; idx < expVal.length; idx++) {
+        itemMatches(actVal[idx], expVal[idx], message, `${m}[${idx}]`);
+      }
+    } else if ("object" === typeof expVal) {
+      itemMatches(actVal, expVal, message, m);
+    } else {
+      assert.strictEqual(actVal, expVal, mPrefix + `${message || "value mismatch"}`);
+    }
+  });
+}
+
+Object.assign(assert, {
+  dateInRange,
+  itemMatches
+});
+module.exports = assert;

--- a/test/setup/assert.js
+++ b/test/setup/assert.js
@@ -26,15 +26,15 @@ function itemMatches(actual, expected, message, parent) {
 
   assert(actual, prefix + `${message || "actual item does not exist"}`);
   Object.keys(expected).forEach((m) => {
-    let mPrefix = `${parent ? parent + "." : ""}.${m}: `;
+    let mPrefix = `${parent ? parent + "." : ""}${m}: `;
     let actVal = actual[m],
         expVal = expected[m];
     
     if (DATE_MEMBERS.indexOf(m) !== -1) {
-      dateInRange(actVal, expVal, prefix + `${m} out of range`);
+      dateInRange(actVal, expVal, mPrefix + `${m} out of range`);
     } else if (Array.isArray(expVal)) {
-      assert(Array.isArray(actVal));
-      assert.strictEqual(actVal.length, expVal.length, prefix + `${message || "array length mismatch"}`);
+      assert(Array.isArray(actVal), mPrefix + `${message || "expected actual to be an array"}`);
+      assert.strictEqual(actVal.length, expVal.length, mPrefix + `${message || "array length mismatch"}`);
       for (let idx = 0; idx < expVal.length; idx++) {
         itemMatches(actVal[idx], expVal[idx], message, `${m}[${idx}]`);
       }

--- a/test/setup/assert.js
+++ b/test/setup/assert.js
@@ -6,7 +6,7 @@
 
 const assert = require("chai").assert;
 
-const ACCEPTED_DELTA_MS = 100;
+const ACCEPTED_DELTA_MS = 250;
 
 function dateInRange(actual, expected, message) {
   actual = new Date(actual);

--- a/test/util/errors-test.js
+++ b/test/util/errors-test.js
@@ -19,6 +19,7 @@ describe("util/errors", () => {
       assert.reasonMatches(DataStoreError.NOT_INITIALIZED, "NOT_INITIALIZED");
       assert.reasonMatches(DataStoreError.INITIALIZED, "INITIALIZED");
       assert.reasonMatches(DataStoreError.LOCKED, "LOCKED");
+      assert.reasonMatches(DataStoreError.INVALID_ITEM, "INVALID_ITEM");
       assert.reasonMatches(DataStoreError.GENERIC_ERROR, "GENERIC_ERROR");
     });
   });


### PR DESCRIPTION
Further resolves mozilla-lockbox/lockbox-extension#103

This enforces the following constraints:

* **title**: length <= 500
* **origins**: length <= 5; [_item_].length <= 500
* **tags**: length <= 10; [_item_].length <= 500
* **entry**:
  * **kind**: == `"login"`
  * **username**: length < 500
  * **password**: length < 500
  * **notes**: length < 10000

Also:
* Any unknown members are stripped.
* Members that are expected to be set on `add` or `update` are forced to sane values.
* History is generated (yeah, should have made this separate):
  * length <= 100