### PR TITLE
Remove moved file in index to fix mkdocs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,6 @@ repo_url: https://github.com/mozilla-lockbox/lockbox-datastore
 
 pages:
 - 'Introduction': 'index.md'
-- 'Data Storage Design': 'data-storage.md'
 - 'Installing': 'install.md'
 - 'Contributing': 'contributing.md'
 - 'Code of Conduct': 'code_of_conduct.md'


### PR DESCRIPTION
Fixes #59 

When I removed the `data-storage.md` doc at #57 I didn't realize it was hard-coded in the TOC which instead of failing gracefully just dies entirely when building the docs.

I'm going to merge this because it worked locally and I want to confirm this fixes everything immediately (and can't make it any worse!).