### PR TITLE
remove default key

### DIFF
--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -11,12 +11,6 @@ const Items = require("./items"),
       localdatabase = require("./localdatabase"),
       jose = require("node-jose");
 
-const DEFAULT_APP_KEY = {
-  "kty": "oct",
-  "kid": "L9-eBkDrYHdPdXV_ymuzy_u9n3drkQcSw5pskrNl4pg",
-  "k": "WsTdZ2tjji2W36JN9vk9s2AYsvp8eYy1pBbKPgcSLL4"
-};
-
 // SHA-256("lockbox encrypt")
 const HKDF_INFO_ENCRYPT = "9UUucG8PDHPGXwM-pGoT0-aFGu74M54k55AykEgOx98";
 // SHA-256("lockbox hashing")
@@ -24,7 +18,7 @@ const HKDF_INFO_HASHING = "pz8gGLGYNLV6haKwjJ1dR-YKX5zDMhPHw2DuXGNu6cw";
 
 async function deriveKeys(appKey, salt) {
   if (!appKey) {
-    appKey = DEFAULT_APP_KEY;
+    throw new TypeError("invalid app key");
   }
   appKey = await jose.JWK.asKey(appKey);
 


### PR DESCRIPTION
Resolves #68 

Removes the default key from datastore entirely, relying on consumers of this module to deal with it in their specific manner.